### PR TITLE
Fix recognizer collection should take multiple recognizers

### DIFF
--- a/BlinkID/MicroblinkBlinkidCapacitor.podspec
+++ b/BlinkID/MicroblinkBlinkidCapacitor.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.author = package['author']
   s.source = { :git => package['repository']['url'], :tag => s.version.to_s }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
-  s.ios.deployment_target  = '12.0'
+  s.ios.deployment_target  = '11.0'
   s.dependency 'Capacitor'
   s.swift_version = '5.4'
   s.dependency 'PPBlinkID', '~> 5.12.0'

--- a/BlinkID/ios/Plugin/Plugin.swift
+++ b/BlinkID/ios/Plugin/Plugin.swift
@@ -56,7 +56,7 @@ public class BlinkIDCapacitorPlugin: CAPPlugin {
                     return
             }
             recognizerRunneViewController.modalPresentationStyle = .fullScreen
-            self.bridge?.viewController?.present(recognizerRunneViewController, animated: true, completion: nil)
+            self.bridge?.viewController.present(recognizerRunneViewController, animated: true, completion: nil)
         }
     }
     

--- a/BlinkID/src/recognizer.ts
+++ b/BlinkID/src/recognizer.ts
@@ -51,7 +51,7 @@ export class RecognizerCollection {
     /** Number of miliseconds after first non-empty result becomes available to end scanning with a timeout */
     milisecondsBeforeTimeout: number;
 
-    constructor(recognizerArray: [Recognizer]) {
+    constructor(recognizerArray: Recognizer[]) {
         this.recognizerArray = recognizerArray;
         this.allowMultipleResults = false;
         this.milisecondsBeforeTimeout = 10000;


### PR DESCRIPTION
The typescript syntax for array type is `[Element]`, but the `recognizerArray` argument typing contains a typo: it says `Element[]` which makes it accept a tuple type with 1 element instead. As a result, `RecognizerCollection` only accepts single recognizer, but the API clearly shows that multiple recognizers should be possible.